### PR TITLE
Fix uuid4 import usage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import uuid
+from uuid import uuid4
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 


### PR DESCRIPTION
## Summary
- import `uuid4` directly so `api_ocr` can generate temp directory names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_684735a06c1083308c782134d67eecf1