### PR TITLE
Remove unused imports and use ROOT_DIR

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,6 @@
 import os
 from pathlib import Path
 import logging
-import shutil, sys
 
 try:
     from dotenv import load_dotenv

--- a/app/main.py
+++ b/app/main.py
@@ -22,14 +22,14 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .ocr_utils import run_ocr
+from . import ROOT_DIR
 
 # ------------------------------------------------------------------
 # Paths
 # ------------------------------------------------------------------
-ROOT = Path(__file__).resolve().parent.parent
-TEMPLATES_DIR = ROOT / "templates"
-STATIC_DIR = ROOT / "static"
-RESULTS_DIR = ROOT / "results"
+TEMPLATES_DIR = ROOT_DIR / "templates"
+STATIC_DIR = ROOT_DIR / "static"
+RESULTS_DIR = ROOT_DIR / "results"
 RESULTS_DIR.mkdir(exist_ok=True)
 
 # ------------------------------------------------------------------
@@ -60,7 +60,7 @@ class Results:
         self.json = self.folder / "result.json"
 
 
-async def _process_pdf(src: Path, task_id: str, model_name: str) -> None:
+def _process_pdf(src: Path, task_id: str, model_name: str) -> None:
     try:
         run_ocr(src, RESULTS_DIR / task_id, model_name=model_name)
     finally:

--- a/app/ocr_utils.py
+++ b/app/ocr_utils.py
@@ -18,7 +18,6 @@ import easyocr
 import fitz
 from PIL import Image
 from PyPDF2 import PdfReader
-from PyPDF2.errors import PdfReadError
 
 __all__ = [
     "run_ocr",


### PR DESCRIPTION
## Summary
- remove unused imports in `app/__init__.py` and `app/ocr_utils.py`
- import `ROOT_DIR` in `app.main` instead of recalculating
- make `_process_pdf` a regular function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68473e7a8bf083308af9b1da85a65ae9